### PR TITLE
Fix/docs and travis

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,10 @@
-node_modules/
+.git
+node_modules
 tmp
 doc
 docs
-.travis.yml
-.git
+.editorconfig
 .gitignore
+.jshintrc
+.travis.yml
 Gruntfile.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ node_js:
   - "10"
   - "8"
 
+cache:
+  directories:
+    - node_modules
+
 before_install:
   - npm install -g grunt-cli
 
@@ -70,10 +74,12 @@ jobs:
         - git config --local user.email "$GITHUB_USER_EMAIL"
         - export GIT_TAG_VERSION=$(npm view ./ version)
         - git tag "v$GIT_TAG_VERSION"
+        - npm pack
       deploy:
         provider: releases
         edge: true
         api_key: "$GITHUB_OAUTH_TOKEN"
+        file: ndigitals-${REPO}-${GIT_TAG_VERSION}.tgz
         skip_cleanup: true
         on:
           condition: -z $(git tag --points-at $TRAVIS_COMMIT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![NPM version](https://badge.fury.io/js/%40ndigitals%2Fgrunt-checkrepo.svg)](https://badge.fury.io/js/%40ndigitals%2Fgrunt-checkrepo)
-[![Build Status](https://travis-ci.org/ndigitals/grunt-checkrepo.svg?branch=master)](https://travis-ci.org/ndigitals/grunt-checkrepo)
+[![Build Status](https://travis-ci.com/ndigitals/grunt-checkrepo.svg?branch=master)](https://travis-ci.com/ndigitals/grunt-checkrepo)
 [![dependencies Status](https://david-dm.org/ndigitals/grunt-checkrepo/status.svg)](https://david-dm.org/ndigitals/grunt-checkrepo)
 [![devDependencies Status](https://david-dm.org/ndigitals/grunt-checkrepo/dev-status.svg)](https://david-dm.org/ndigitals/grunt-checkrepo?type=dev)
 [![NPM Downloads](https://img.shields.io/npm/dm/@ndigitals/grunt-checkrepo)](https://www.npmjs.com/package/@ndigitals/grunt-checkrepo)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ndigitals/grunt-checkrepo",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
+    "lint": "grunt jshint",
     "test": "grunt test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ndigitals/grunt-checkrepo",
   "description": "Check the state of repository.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/ndigitals/grunt-checkrepo",
   "author": "Darsain (http://darsa.in)",
   "contributors": [


### PR DESCRIPTION
* Updates build status in README to point to the Travis CI .com domain.
* Changes GitHub release to include an NPM packed distribution.